### PR TITLE
Remove USB DMX option

### DIFF
--- a/ConsoleDMX_2025_AIO.ino
+++ b/ConsoleDMX_2025_AIO.ino
@@ -1359,7 +1359,7 @@ void webSocketEvent(uint8_t num, WStype_t type, uint8_t* payload, size_t length)
             nm.replace("|", " ");
             nm.replace(",", " ");
             nm.replace(":", " ");
-            cfg.dmx_protocol = (uint8_t)constrain(proto, 0, 3);
+            cfg.dmx_protocol = (uint8_t)constrain(proto, 0, 2);
             cfg.universe = (uint8_t)constrain(unv, 0, 255);
             cfg.priority = (uint8_t)constrain(pr, 0, 2);
             strncpy(cfg.nodeName, nm.c_str(), sizeof(cfg.nodeName) - 1);

--- a/index.html
+++ b/index.html
@@ -420,7 +420,6 @@
             <option value="0" data-i18n-key="disabled">Désactivé</option>
             <option value="1" data-i18n-key="artnet">Art-Net</option>
             <option value="2" data-i18n-key="sacn">sACN (E1.31)</option>
-            <option value="3" data-i18n-key="usbdmx">USB DMX (OpenDMX)</option>
           </select>
         </div>
         <div><label class="inline" data-i18n-key="universe">Univers</label><input type="number" id="univ" min="0" max="255"></div>
@@ -529,7 +528,6 @@ const translations = {
     disabled: "Désactivé",
     artnet: "Art-Net",
     sacn: "sACN (E1.31)",
-    usbdmx: "USB DMX (type OpenDMX)",
     prio_faders: "Faders",
     prio_net: "DMX sur IP",
     prio_htp: "Fusion HTP (max)",
@@ -655,7 +653,6 @@ const translations = {
     disabled: "Disabled",
     artnet: "Art-Net",
     sacn: "sACN (E1.31)",
-    usbdmx: "USB DMX (OpenDMX type)",
     prio_faders: "Faders",
     prio_net: "DMX over IP",
     prio_htp: "HTP Merge (max)",


### PR DESCRIPTION
This commit removes the "USB DMX" option from the list of available DMX protocols.

The changes include:
- Removing the option from the dropdown menu in `index.html`.
- Removing the corresponding i18n translation keys for "usbdmx" in `index.html`.
- Adjusting the backend logic in `ConsoleDMX_2025_AIO.ino` to no longer accept the value for the USB DMX protocol.